### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Scott Day
 maintainer=Nobody
 sentence=Examples for using the ESP Software serial receiver
 paragraph=Examples for using the ESP Software serial receiver
+category=Communication
 url=https://github.com/scottwday/EspSoftSerial
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library ESP Soft Serial is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
